### PR TITLE
Adds gasless vouching support for smart contract wallets

### DIFF
--- a/src/controllers/vouch/add.ts
+++ b/src/controllers/vouch/add.ts
@@ -1,24 +1,39 @@
 import { RequestHandler } from 'express';
 import Joi from '@hapi/joi';
 // eslint-disable-next-line camelcase
-import { recoverTypedSignature_v4 } from 'eth-sig-util';
+import { recoverTypedSignature_v4, TypedDataUtils } from 'eth-sig-util';
 import { ethers } from 'ethers';
 import requestMiddleware from '../../middleware/request-middleware';
 import { Vouch } from '../../models';
 import pohAbi from '../../abis/proof-of-humanity.json';
+import logger from '../../logger';
 
 const addVouchSchema = Joi.object().keys({
   signature: Joi.string().required(),
-  msgData: Joi.string().required()
+  msgData: Joi.string().required(),
+  voucherAddress: Joi.string().required(),
 });
 
 const provider = new ethers.providers.InfuraProvider('homestead', process.env.INFURA_KEY);
 const poh = new ethers.Contract(process.env.POH_ADDRESS, pohAbi, provider);
+const eip1271Abi = `[{"constant":true,"inputs":[{"name":"_messageHash","type":"bytes32"},{"name":"_signature","type":"bytes"}],"name":"isValidSignature","outputs":[{"name":"magicValue","type":"bytes4"}],"payable":false,"stateMutability":"view","type":"function"}]`;
+
+// Returns true if the contract wallet considers the signature valid (EIP-1271)
+async function isValidEIP1271Signature(msgData: Buffer, signature: string, walletAddress: string): Promise<boolean> {
+  const eip1271Contract = new ethers.Contract(walletAddress, eip1271Abi, provider);
+  try {
+    const retVal = await eip1271Contract.isValidSignature(msgData, signature);
+    return retVal == 0x1626ba7e;
+  } catch (error) {
+    return false;
+  }
+}
 
 const add: RequestHandler = async (req, res) => {
   const {
     signature,
-    msgData: msgDataString
+    msgData: msgDataString,
+    voucherAddress
   } = req.body;
   const msgData = JSON.parse(msgDataString);
 
@@ -28,10 +43,26 @@ const add: RequestHandler = async (req, res) => {
     voucherExpirationTimestamp: expirationTimestamp
   } = message || {};
 
-  const voucherAddr = recoverTypedSignature_v4({
+  let voucherAddr = recoverTypedSignature_v4({
     data: msgData,
     sig: signature
   });
+
+  if (voucherAddr.toUpperCase() != voucherAddress.toUpperCase()) {
+    // If the address is a smart contract wallet, check for EIP-1271 support
+    const theMsgHash = TypedDataUtils.sign(msgData);
+    const validSig = await isValidEIP1271Signature(theMsgHash, signature, voucherAddress);
+    if (!validSig) { 
+      logger.error("Invalid signature");
+      res.status(400).json({
+        message: "Invalid signature.",
+      });
+      return;
+    }
+
+    // Contract verified the sig, allow the voucher address to be used
+    voucherAddr = voucherAddress;
+  }
 
   if (!(await poh.isRegistered(voucherAddr))) {
     res.status(400).json({


### PR DESCRIPTION
This is done by adding support for EIP-1271 when verifying the voucher's signature.

- First try the existing recoverTypedSignature_v4() function
- If the recovered address matches the passed-in address (new parameter passed over http request), the signature is valid, and continue on as before
- If case-insensitive addresses do not match, the requesting address may be a contract, so call isValidSignature() on it. It's up to the contract (if it is one) to determine sig validity. Non-contracts will fail via exception when attempt to call the method, but contracts have a chance to work (depends on the contract's support for EIP-1271)

NOTE: This change requires another change for https://github.com/Proof-Of-Humanity/proof-of-humanity-web. I'm not sure how to best proceed here, since they are 2 different depots. I'm thinking to put up 2 pull requests separately, but is there a better way to handle dependencies? Thanks!

References
https://eips.ethereum.org/EIPS/eip-1271
https://docs.argent.xyz/wallet-connect-and-argent#message-signature